### PR TITLE
update js-tokens@^3.0.0 / improve performance ~4x

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "tap test/*.js"
   },
   "dependencies": {
-    "js-tokens": "^2.0.0"
+    "js-tokens": "^3.0.0"
   },
   "devDependencies": {
     "browserify": "^13.1.1",

--- a/replace.js
+++ b/replace.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var jsTokens = require('js-tokens');
+var jsTokens = require('js-tokens').default;
 
 var processEnvRe = /\bprocess\.env\.[_$a-zA-Z][$\w]+\b/;
 var spaceOrCommentRe = /^(?:\s|\/[/*])/;


### PR DESCRIPTION
This brings [a performance boost](https://github.com/lydell/js-tokens/blob/master/CHANGELOG.md#version-300-2017-01-11).

On my machine, running `node bench/bench.js ../` went from ~80ms to ~20ms.