### PR TITLE
Bump js-tokens to version 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "tap test/*.js"
   },
   "dependencies": {
-    "js-tokens": "^3.0.0"
+    "js-tokens": "^4.0.0"
   },
   "devDependencies": {
     "browserify": "^13.1.1",


### PR DESCRIPTION
Version 4 brings compatibility with ES2018 and a potential performance improvement (due to https://github.com/lydell/js-tokens/commit/9d18b7ea07744e2f4dfbeb46ce557a4a65b44ade)