### PR TITLE
Upgrade js-tokens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
-sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
-  - "4"
-  - "5"
-  - "6"
-  - "7"
+  - "10"
+  - "12"
+  - "node"

--- a/README.md
+++ b/README.md
@@ -2,16 +2,11 @@
 
 [![Build Status](https://travis-ci.org/zertosh/loose-envify.svg?branch=master)](https://travis-ci.org/zertosh/loose-envify)
 
-Fast (and loose) selective `process.env` replacer using [js-tokens](https://github.com/lydell/js-tokens) instead of an AST. Works just like [envify](https://github.com/hughsk/envify) but much faster.
+Selective `process.env` replacer using [js-tokens](https://github.com/lydell/js-tokens) instead of an AST. Works just like [envify](https://github.com/hughsk/envify) but a tiny bit faster.
 
 ## Gotchas
 
-* Doesn't handle broken syntax.
-* Doesn't look inside embedded expressions in template strings.
-  - **this won't work:**
-  ```js
-  console.log(`the current env is ${process.env.NODE_ENV}`);
-  ```
+* Doesn't report broken syntax.
 * Doesn't replace oddly-spaced or oddly-commented expressions.
   - **this won't work:**
   ```js
@@ -28,18 +23,18 @@ loose-envify has the exact same interface as [envify](https://github.com/hughsk/
 envify:
 
   $ for i in {1..5}; do node bench/bench.js 'envify'; done
-  708ms
-  727ms
-  791ms
-  719ms
-  720ms
+  113ms
+  125ms
+  112ms
+  115ms
+  114ms
 
 loose-envify:
 
   $ for i in {1..5}; do node bench/bench.js '../'; done
-  51ms
-  52ms
-  52ms
-  52ms
-  52ms
+  85ms
+  90ms
+  83ms
+  84ms
+  81ms
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "loose-envify",
   "version": "1.4.0",
-  "description": "Fast (and loose) selective `process.env` replacer using js-tokens instead of an AST",
+  "description": "Selective `process.env` replacer using js-tokens instead of an AST",
   "keywords": [
     "environment",
     "variables",

--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
     "test": "tap test/*.js"
   },
   "dependencies": {
-    "js-tokens": "^3.0.0 || ^4.0.0"
+    "js-tokens": "^6.0.0"
   },
   "devDependencies": {
-    "browserify": "^13.1.1",
-    "envify": "^3.4.0",
-    "tap": "^8.0.0"
+    "browserify": "^16.5.0",
+    "envify": "^4.1.0",
+    "tap": "^14.10.7"
   }
 }


### PR DESCRIPTION
This allows stuff like ``console.log(`the current env is ${process.env.NODE_ENV}`)``. Also, it makes the tokenization more correct in general (but a little bit slower).

js-tokens@6 uses [Unicode Property Escapes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions/Unicode_Property_Escapes), which **requires Node.js 10 or later.**